### PR TITLE
feat: suppress error messages by npm scripts

### DIFF
--- a/templates/minimum/package.json.tmpl
+++ b/templates/minimum/package.json.tmpl
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     <% if (enablePluginUploader) { %>
-    "start": "npm-run-all -p develop upload",
+    "start": "node scripts/npm-start.js",
     "upload": "kintone-plugin-uploader dist/plugin.zip --watch --waiting-dialog-ms 3000",
     <% } else { %>
     "start": "npm run develop",

--- a/templates/minimum/scripts/npm-start.js
+++ b/templates/minimum/scripts/npm-start.js
@@ -1,0 +1,15 @@
+"use strict";
+const runAll = require("npm-run-all");
+
+runAll(["develop", "upload"], {
+  parallel: true,
+  stdout: process.stdout,
+  stdin: process.stdin
+}).catch(({results}) => {
+  results
+    .filter(({code}) => code)
+    .forEach(({name}) => {
+      console.log(`"npm run ${name}" was failed`);
+    })
+  ;
+});


### PR DESCRIPTION
Currently, `npm start` prints error messages from npm scripts, which is very confusing for users using create-plugin.
This PR is to suppress the messages by using Node API of `npm-run-all`.
This PR changes the behavior of `npm start` scripts. Previously `npm start` finished with ERROR CODE if any errors occured. After this PR, `npm start` will finish with exit code 0. This is required to suppress the message generated by npm scripts.
